### PR TITLE
Fp 22 refactor backend

### DIFF
--- a/dynamo_handler.py
+++ b/dynamo_handler.py
@@ -1,4 +1,5 @@
 import boto3
+import time
 from boto3.dynamodb.conditions import Key, Attr
 
 class DynamoDBHandler:

--- a/ingester.py
+++ b/ingester.py
@@ -97,6 +97,15 @@ def store_player_in_ddb(players: list):
         )
 
 def main():
+    if len(sys.argv) < 3:
+        print("Usage: uv run <parameter>")
+        sys.exit(1)
+    
+    remove_ddb_table = sys.argv[1]
+    ap_type = sys.argv[2]
+
+    print(f"Working with access pattern: {ap_type}")
+
     if remove_ddb_table == "y":
         ddb_handler.recreate_table('manual-fapi-ddb')
         time.sleep(10)
@@ -110,13 +119,11 @@ def main():
     
     # Routing logic (switch-like behavior)
     ap_router = {
-        "AP1": lambda: process_match_data_for_players(players_data, access_pattern="AP1"),
-        "AP2": lambda: store_player_in_ddb(players_data),
-        "AP3": lambda: process_match_data_for_players(players_data, access_pattern="AP3"),
+        "ap1": lambda: process_match_data_for_players(players_data, access_pattern="AP1"),
+        "ap2": lambda: store_player_in_ddb(players_data),
+        "ap3": lambda: process_match_data_for_players(players_data, access_pattern="AP3"),
     }
-
-    ap_type = "AP3"
-
+    
     if ap_type in ap_router:
         ap_router[ap_type]()
     else:

--- a/ingester.py
+++ b/ingester.py
@@ -28,7 +28,7 @@ def transform_players_data(players_data: dict) -> list:
                 'name': player.get('pDName', '').lower(),
                 'goals': player.get('gS', ''),
                 'assist': player.get('assist', ''),
-                'team': player.get('cCode', ''),
+                'team': player.get('tName', ''),
                 'position': skill_description
             })
 

--- a/ingester.py
+++ b/ingester.py
@@ -1,3 +1,4 @@
+import sys
 import logging
 import http.client
 import json
@@ -80,8 +81,14 @@ def process_match_data_for_players(player_data, access_pattern):
             match_date = transform_date(fixtures[matches]['dateTime'])
 
             if access_pattern == 'AP1':
+                """
+                Handles AP1: Write all matches for a specific player.
+                """
                 ddb_handler.write_match_player(player['name'], match_id, goals_scored, assists, match_date)
             elif access_pattern == 'AP3':
+                """
+                Handles AP3: Write all data about matches.
+                """
                 ddb_handler.write_match_data(player['name'], match_id, goals_scored, assists, player['position'], match_date)
 
 def store_player_in_ddb(players: list):

--- a/ingester.py
+++ b/ingester.py
@@ -97,6 +97,10 @@ def store_player_in_ddb(players: list):
         )
 
 def main():
+    if remove_ddb_table == "y":
+        ddb_handler.recreate_table('manual-fapi-ddb')
+        time.sleep(10)
+    
     """Put items in ddb database"""
     ingester_start_time = time.time()
     uefa_start_time = time.time()


### PR DESCRIPTION
Although the title of this pull request may say fp-22, the reality is that this is more about optimizing ddb operations.

Running the algorithm would take more than 13 minutes, which is perhaps the max timeout that a lambda can be set.

By implementing a router in the ingester function, we can break down the execution operations in the three access patterns defined for the ddb table:
- ap1: write all data about players for all the matches
- ap2: write total aggregate players data
- ap3: write all data about matches

Another pull request will perhaps be open for the actual refactoring, e.g. hexagonal architecture or ddb batch writes.